### PR TITLE
Feature price range filtering

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,6 +7,6 @@ class PagesController < ApplicationController
   end
 
   def filters_params
-    params.permit(:category, :brand)
+    params.permit(:category_id, :brand_id, price_range_ids: [])
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,10 +2,7 @@
 
 class PagesController < ApplicationController
   def home
-    @active_filters = filters_params || { filters: '' }
-    @products = Product.all.with_attached_main_image
-    @products = @products.filter_by_category(@active_filters[:category]) if @active_filters[:category].present?
-    @products = @products.filter_by_brand(@active_filters[:brand]) if @active_filters[:brand].present?
+    @products = Products::FilterProducts.new.call(filters_params)
     @products = @products.decorate
   end
 

--- a/app/models/price_range.rb
+++ b/app/models/price_range.rb
@@ -3,7 +3,7 @@
 class PriceRange < ApplicationRecord
   def name
     if min.zero?
-      "under $#{max}"
+      "Under $#{max}"
     elsif max == Float::INFINITY
       "$#{min} & Above"
     else

--- a/app/models/price_range.rb
+++ b/app/models/price_range.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PriceRange < ApplicationRecord
+  def name
+    if min.zero?
+      "under $#{max}"
+    elsif max == Float::INFINITY
+      "$#{min} & Above"
+    else
+      "$#{min} to $#{max}"
+    end
+  end
+
+  def range
+    min..max
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,8 +6,6 @@ class Product < ApplicationRecord
   has_one_attached :main_image
   belongs_to :category, optional: true
   belongs_to :brand, optional: true
-  scope :filter_by_category, ->(category_id) { where category_id: category_id }
-  scope :filter_by_brand, ->(brand_id) { where brand_id: brand_id }
   has_many :cart_items, dependent: :destroy
   has_many :order_items, dependent: :destroy
 end

--- a/app/querries/products/filter_products.rb
+++ b/app/querries/products/filter_products.rb
@@ -2,20 +2,24 @@
 
 module Products
   class FilterProducts
+
+    def initialize(scope = Product.all.with_attached_main_image)
+      @scope = scope
+    end
+
     def call(params)
-      scoped = Product.all.with_attached_main_image
-      scoped = filter_by_brand(scoped, params[:brand_id])
-      filter_by_category(scoped, params[:category_id])
+      @scope = filter_by_brand(params[:brand_id])
+      filter_by_category(params[:category_id])
     end
 
     private
 
-    def filter_by_brand(scoped, brand_id)
-      brand_id ? scoped.where(brand_id: brand_id) : scoped
+    def filter_by_brand(brand_id)
+      brand_id ? @scope.where(brand_id: brand_id) : @scope
     end
 
-    def filter_by_category(scoped, category_id)
-      category_id ? scoped.where(category_id: category_id) : scoped
+    def filter_by_category(category_id)
+      category_id ? @scope.where(category_id: category_id) : @scope
     end
   end
 end

--- a/app/querries/products/filter_products.rb
+++ b/app/querries/products/filter_products.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Products
+  class FilterProducts
+    def call(params)
+      scoped = Product.all.with_attached_main_image
+      scoped = filter_by_brand(scoped, params[:brand_id])
+      filter_by_category(scoped, params[:category_id])
+    end
+
+    private
+
+    def filter_by_brand(scoped, brand_id)
+      brand_id ? scoped.where(brand_id: brand_id) : scoped
+    end
+
+    def filter_by_category(scoped, category_id)
+      category_id ? scoped.where(category_id: category_id) : scoped
+    end
+  end
+end

--- a/app/querries/products/filter_products.rb
+++ b/app/querries/products/filter_products.rb
@@ -2,14 +2,14 @@
 
 module Products
   class FilterProducts
-
     def initialize(scope = Product.all.with_attached_main_image)
       @scope = scope
     end
 
     def call(params)
       @scope = filter_by_brand(params[:brand_id])
-      filter_by_category(params[:category_id])
+      @scope = filter_by_category(params[:category_id])
+      filter_by_price_ranges(params[:price_range_ids])
     end
 
     private
@@ -20,6 +20,15 @@ module Products
 
     def filter_by_category(category_id)
       category_id ? @scope.where(category_id: category_id) : @scope
+    end
+
+    def filter_by_price_ranges(price_range_ids)
+      if price_range_ids
+        price_ranges = price_range_ids.map { |id| PriceRange.find(id).range }
+        @scope.where(price: price_ranges)
+      else
+        @scope
+      end
     end
   end
 end

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -18,13 +18,13 @@
     <% PriceRange.all.sort_by(&:min).each do |price_range| %>
       <div class="form-check">
         <% checked = params[:price_range_ids]&.include?(price_range.id.to_s) %>
-        <%= check_box_tag("price_range_ids[]", price_range.id, checked, class: "checkbox", id: "price_range_checkbox_#{price_range.id}") %>
-        <%= price_range.name %>
+        <%= check_box_tag("price_range_ids[]", price_range.id, checked, class: "checkbox", id: "price-range-checkbox-#{price_range.id}") %>
+        <%= label_tag(price_range.name, nil,  class: "form-check-label", for: "price-range-checkbox-#{price_range.id}") %>
       </div>
     <% end %>
     
     <%= hidden_field_tag :category_id, params[:category_id] if params[:category_id] %>
     <%= hidden_field_tag :brand_id, params[:brand_id] if params[:brand_id] %>
-    <%= submit_tag('Filter', name: nil, class: "btn btn-block btn-outline-primary", id: "filter_button" ) %>
+    <%= submit_tag('Filter', name: nil, class: "btn btn-block btn-outline-primary", id: "filter-button" ) %>
   <% end %>
 <% end %>

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -15,19 +15,16 @@
 <% if request.params[:brand_id] || request.params[:category_id] %>
   <h4 class="my-4">Price Ranges</h4>
   <%= form_tag("/", method: :get) do %>
-    <% PriceRange.all.each do |price_range| %>
+    <% PriceRange.all.sort_by(&:min).each do |price_range| %>
       <div class="form-check">
-        <% if params[:price_range_ids]&.include?(price_range.id.to_s)%>
-          <%= check_box_tag("price_range_ids[]", price_range.id, true, class: "checkbox") %>
-        <% else %>
-          <%= check_box_tag("price_range_ids[]", price_range.id, false, class: "checkbox") %>
-        <% end %>
+        <% checked = params[:price_range_ids]&.include?(price_range.id.to_s) %>
+        <%= check_box_tag("price_range_ids[]", price_range.id, checked, class: "checkbox", id: "price_range_checkbox_#{price_range.id}") %>
         <%= price_range.name %>
       </div>
     <% end %>
-
+    
     <%= hidden_field_tag :category_id, params[:category_id] if params[:category_id] %>
     <%= hidden_field_tag :brand_id, params[:brand_id] if params[:brand_id] %>
-    <%= submit_tag('Filter', name: nil, class: 'btn btn-block btn-outline-primary' ) %>
+    <%= submit_tag('Filter', name: nil, class: "btn btn-block btn-outline-primary", id: "filter_button" ) %>
   <% end %>
 <% end %>

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -1,13 +1,13 @@
 <h4 class="my-4">Categories</h4>
 <div class="list-group">
   <% Category.all.each do |category|%>
-    <%= link_to category.name, root_path(@active_filters.merge(category: category.id)), class: "list-group-item" %>
+    <%= link_to category.name, request.params.merge(category_id: category.id), class: "list-group-item" %>
   <% end %>
 </div>
 
 <h4 class="my-4">Brands</h4>
 <div class="list-group">
   <% Brand.all.each do |brand|%>
-    <%= link_to brand.name, root_path(@active_filters.merge(brand: brand.id)), class: "list-group-item" %>
+    <%= link_to brand.name, request.params.merge(brand_id: brand.id), class: "list-group-item" %>
   <% end %>
 </div>

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -1,13 +1,33 @@
 <h4 class="my-4">Categories</h4>
 <div class="list-group">
-  <% Category.all.each do |category|%>
-    <%= link_to category.name, request.params.merge(category_id: category.id), class: "list-group-item" %>
+  <% Category.all.each do |category| %>
+    <%= link_to category.name, request.params.except(:price_range_ids, :commit).merge(category_id: category.id), class: "list-group-item" %>
   <% end %>
 </div>
 
 <h4 class="my-4">Brands</h4>
 <div class="list-group">
-  <% Brand.all.each do |brand|%>
-    <%= link_to brand.name, request.params.merge(brand_id: brand.id), class: "list-group-item" %>
+  <% Brand.all.each do |brand| %>
+    <%= link_to brand.name, request.params.except(:price_range_ids, :commit).merge(brand_id: brand.id), class: "list-group-item" %>
   <% end %>
 </div>
+
+<% if request.params[:brand_id] || request.params[:category_id] %>
+  <h4 class="my-4">Price Ranges</h4>
+  <%= form_tag("/", method: :get) do %>
+    <% PriceRange.all.each do |price_range| %>
+      <div class="form-check">
+        <% if params[:price_range_ids]&.include?(price_range.id.to_s)%>
+          <%= check_box_tag("price_range_ids[]", price_range.id, true, class: "checkbox") %>
+        <% else %>
+          <%= check_box_tag("price_range_ids[]", price_range.id, false, class: "checkbox") %>
+        <% end %>
+        <%= price_range.name %>
+      </div>
+    <% end %>
+
+    <%= hidden_field_tag :category_id, params[:category_id] if params[:category_id] %>
+    <%= hidden_field_tag :brand_id, params[:brand_id] if params[:brand_id] %>
+    <%= submit_tag('Filter', name: nil, class: 'btn btn-block btn-outline-primary' ) %>
+  <% end %>
+<% end %>

--- a/db/migrate/20211028151840_create_price_ranges.rb
+++ b/db/migrate/20211028151840_create_price_ranges.rb
@@ -1,0 +1,8 @@
+class CreatePriceRanges < ActiveRecord::Migration[6.1]
+  def change
+    create_table :price_ranges do |t|
+      t.float :min
+      t.float :max
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_03_203639) do
+ActiveRecord::Schema.define(version: 2021_10_28_151840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,6 +100,11 @@ ActiveRecord::Schema.define(version: 2021_09_03_203639) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["order_id"], name: "index_payments_on_order_id"
+  end
+
+  create_table "price_ranges", force: :cascade do |t|
+    t.float "min"
+    t.float "max"
   end
 
   create_table "products", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,6 +23,13 @@ Brand.destroy_all
   )
 end
 
+puts 'generating PriceRanges'
+PriceRange.destroy_all
+PriceRange.create(min: 0, max: 10)
+PriceRange.create(min: 11, max: 20)
+PriceRange.create(min: 51, max: Float::INFINITY)
+PriceRange.create(min: 21, max: 50)
+
 puts 'generating Products'
 Product.destroy_all
 20.times do 

--- a/spec/factories/price_ranges.rb
+++ b/spec/factories/price_ranges.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :price_range do
+    min { 10 }
+    max { 20 }
+  end
+end

--- a/spec/requests/products/get_products_request_spec.rb
+++ b/spec/requests/products/get_products_request_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe '/', type: :request do
   describe 'GET /' do
-    subject(:request_call) { get "/#{params}" }
     let!(:price_range1) { create(:price_range, min: 0, max: 10) }
     let!(:price_range2) { create(:price_range, min: 11, max: 20) }
     let!(:product1) { create(:product, price: 5) }
@@ -12,42 +11,39 @@ RSpec.describe '/', type: :request do
     let!(:product3) { create(:product, price: 25) }
 
     context 'when no price filters are applied' do
-      let(:params) { '' }
-
       it 'returns all products' do
-        request_call
+        get '/'
         expect(response.body).to include(product1.name)
-        expect(response.body).to include(product2.name)
-        expect(response.body).to include(product3.name)
+          .and include(product2.name)
+          .and include(product3.name)
       end
     end
 
     context 'when one price filter value is passed' do
-      let(:params) { "?price_range_ids[]=#{price_range1.id}" }
+      before do
+        get "/?price_range_ids[]=#{price_range1.id}"
+      end
 
       it 'returns a product from selected price range' do
-        request_call
         expect(response.body).to include(product1.name)
       end
 
       it 'does not return products out of selected price range' do
-        request_call
-        expect(response.body).not_to include(product2.name)
-        expect(response.body).not_to include(product3.name)
+        expect(response.body).not_to include(product2.name, product3.name)
       end
     end
 
     context 'when two price filter values are passed' do
-      let(:params) { "?price_range_ids[]=#{price_range1.id}&price_range_ids[]=#{price_range2.id}" }
+      before do
+        get "/?price_range_ids[]=#{price_range1.id}&price_range_ids[]=#{price_range2.id}"
+      end
 
       it 'returns products from selected price range' do
-        request_call
         expect(response.body).to include(product1.name)
-        expect(response.body).to include(product2.name)
+          .and include(product2.name)
       end
 
       it 'does not return products out of selected price range' do
-        request_call
         expect(response.body).not_to include(product3.name)
       end
     end

--- a/spec/requests/products/get_products_request_spec.rb
+++ b/spec/requests/products/get_products_request_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/', type: :request do
+  describe 'GET /' do
+    subject(:request_call) { get "/#{params}" }
+    let!(:price_range1) { create(:price_range, min: 0, max: 10) }
+    let!(:price_range2) { create(:price_range, min: 11, max: 20) }
+    let!(:product1) { create(:product, price: 5) }
+    let!(:product2) { create(:product, price: 15) }
+    let!(:product3) { create(:product, price: 25) }
+
+    context 'when no price filters are applied' do
+      let(:params) { '' }
+
+      it 'returns all products' do
+        request_call
+        expect(response.body).to include(product1.name)
+        expect(response.body).to include(product2.name)
+        expect(response.body).to include(product3.name)
+      end
+    end
+
+    context 'when one price filter value is passed' do
+      let(:params) { "?price_range_ids[]=#{price_range1.id}" }
+
+      it 'returns a product from selected price range' do
+        request_call
+        expect(response.body).to include(product1.name)
+      end
+
+      it 'does not return products out of selected price range' do
+        request_call
+        expect(response.body).not_to include(product2.name)
+        expect(response.body).not_to include(product3.name)
+      end
+    end
+
+    context 'when two price filter values are passed' do
+      let(:params) { "?price_range_ids[]=#{price_range1.id}&price_range_ids[]=#{price_range2.id}" }
+
+      it 'returns products from selected price range' do
+        request_call
+        expect(response.body).to include(product1.name)
+        expect(response.body).to include(product2.name)
+      end
+
+      it 'does not return products out of selected price range' do
+        request_call
+        expect(response.body).not_to include(product3.name)
+      end
+    end
+  end
+end

--- a/spec/system/price_filter_system_spec.rb
+++ b/spec/system/price_filter_system_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Price Filter', type: :system do
+  let!(:category) { create(:category) }
+  let!(:price_range1) { create(:price_range, min: 0, max: 10) }
+  let!(:price_range2) { create(:price_range, min: 11, max: 20) }
+  let!(:product1) { create(:product, category: category, price: 5) }
+  let!(:product2) { create(:product, category: category, price: 15) }
+
+  context 'when one Price Range is selected' do
+    before do
+      visit '/'
+      click_on category.name
+      check "price-range-checkbox-#{price_range1.id}"
+      find('#filter-button').click
+    end
+
+    it 'displays only a product from selected price range' do
+      expect(page).to have_css('h4.card-title', text: product1.name)
+    end
+
+    it 'does not display any products from outside selected price range' do
+      expect(page).to have_no_css('h4.card-title', text: product2.name)
+    end
+  end
+
+  context 'when multiple Price Ranges are selected' do
+    before do
+      visit '/'
+      click_on category.name
+      check "price-range-checkbox-#{price_range1.id}"
+      check "price-range-checkbox-#{price_range2.id}"
+      find('#filter-button').click
+    end
+
+    it 'displays only products from selected price range' do
+      expect(page).to have_css('h4.card-title', text: product1.name)
+        .and have_css('h4.card-title', text: product2.name)
+    end
+  end
+
+  context 'when no Price Range is selected' do
+    before do
+      visit '/'
+      click_on category.name
+      find('#filter-button').click
+    end
+
+    it 'displays all products' do
+      expect(page).to have_css('h4.card-title', text: product1.name)
+        .and have_css('h4.card-title', text: product2.name)
+    end
+  end
+end

--- a/spec/system/price_filter_visibility_system_spec.rb
+++ b/spec/system/price_filter_visibility_system_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Price Filter Visibility', type: :system do
+  let!(:category) { create(:category) }
+  let!(:brand) { create(:brand) }
+  let!(:price_range_1) { create(:price_range, min: 0, max: 10) }
+  let!(:price_range_2) { create(:price_range, min: 11, max: 20) }
+
+  context 'when no filters are applied' do
+    it 'does not display Price Ranges filter' do
+      visit '/'
+
+      expect(page).to have_no_css('h4.my-4', text: 'Price Ranges')
+        .and have_no_css('.form-check-label', text: price_range_1.name)
+        .and have_no_css('.form-check-label', text: price_range_2.name)
+    end
+  end
+
+  context 'when only Category filter is applied' do
+    before do
+      visit '/'
+      click_on category.name
+    end
+
+    it 'displays Price Ranges filter' do
+      expect(page).to have_css('h4.my-4', text: 'Price Ranges')
+        .and have_css('.form-check-label', text: price_range_1.name)
+        .and have_css('.form-check-label', text: price_range_2.name)
+    end
+  end
+
+  context 'when only Brand filter is applied' do
+    before do
+      visit '/'
+      click_on brand.name
+    end
+
+    it 'displays Price Ranges filter' do
+      expect(page).to have_css('h4.my-4', text: 'Price Ranges')
+        .and have_css('.form-check-label', text: price_range_1.name)
+        .and have_css('.form-check-label', text: price_range_2.name)
+    end
+  end
+
+  context 'when Brand and Category filters are applied' do
+    before do
+      visit '/'
+      click_on brand.name
+      click_on category.name
+    end
+
+    it 'displays Price Ranges filter' do
+      expect(page).to have_css('h4.my-4', text: 'Price Ranges')
+        .and have_css('.form-check-label', text: price_range_1.name)
+        .and have_css('.form-check-label', text: price_range_2.name)
+    end
+  end
+end

--- a/spec/system/price_filter_visibility_system_spec.rb
+++ b/spec/system/price_filter_visibility_system_spec.rb
@@ -5,16 +5,16 @@ require 'rails_helper'
 RSpec.describe 'Price Filter Visibility', type: :system do
   let!(:category) { create(:category) }
   let!(:brand) { create(:brand) }
-  let!(:price_range_1) { create(:price_range, min: 0, max: 10) }
-  let!(:price_range_2) { create(:price_range, min: 11, max: 20) }
+  let!(:price_range1) { create(:price_range, min: 0, max: 10) }
+  let!(:price_range2) { create(:price_range, min: 11, max: 20) }
 
   context 'when no filters are applied' do
     it 'does not display Price Ranges filter' do
       visit '/'
 
       expect(page).to have_no_css('h4.my-4', text: 'Price Ranges')
-        .and have_no_css('.form-check-label', text: price_range_1.name)
-        .and have_no_css('.form-check-label', text: price_range_2.name)
+        .and have_no_css('.form-check-label', text: price_range1.name)
+        .and have_no_css('.form-check-label', text: price_range2.name)
     end
   end
 
@@ -26,8 +26,8 @@ RSpec.describe 'Price Filter Visibility', type: :system do
 
     it 'displays Price Ranges filter' do
       expect(page).to have_css('h4.my-4', text: 'Price Ranges')
-        .and have_css('.form-check-label', text: price_range_1.name)
-        .and have_css('.form-check-label', text: price_range_2.name)
+        .and have_css('.form-check-label', text: price_range1.name)
+        .and have_css('.form-check-label', text: price_range2.name)
     end
   end
 
@@ -39,8 +39,8 @@ RSpec.describe 'Price Filter Visibility', type: :system do
 
     it 'displays Price Ranges filter' do
       expect(page).to have_css('h4.my-4', text: 'Price Ranges')
-        .and have_css('.form-check-label', text: price_range_1.name)
-        .and have_css('.form-check-label', text: price_range_2.name)
+        .and have_css('.form-check-label', text: price_range1.name)
+        .and have_css('.form-check-label', text: price_range2.name)
     end
   end
 
@@ -53,8 +53,8 @@ RSpec.describe 'Price Filter Visibility', type: :system do
 
     it 'displays Price Ranges filter' do
       expect(page).to have_css('h4.my-4', text: 'Price Ranges')
-        .and have_css('.form-check-label', text: price_range_1.name)
-        .and have_css('.form-check-label', text: price_range_2.name)
+        .and have_css('.form-check-label', text: price_range1.name)
+        .and have_css('.form-check-label', text: price_range2.name)
     end
   end
 end


### PR DESCRIPTION
As a shopper, I would like to choose the price range of filtered items, so I can narrow down the number of items I am browsing.

- [x] After filtering by brand or category, a shopper sees a list with predefined price ranges (e.g., "Under $10.00", "$10.00-$15.00", "$15.00-$20.00", "$20.00 or over")
- [x] A shopper can choose one or more price ranges
- [x] After confirming the search, a shopper can see only products within one of the chosen price ranges
- [x] There is a system & request spec

